### PR TITLE
Earlier versions of TinyMCE break Plomino by calling forms.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='plomino.tinymce',
       install_requires=[
           'setuptools',
           # -*- Extra requirements: -*-
-          'Products.TinyMCE',
+          'Products.TinyMCE >= 1.2.13',
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
A condition in tinymce_wysiwyg_support.pt rendered form objects,
triggering events. Current TinyMCE uses 'nocall:', so doesn't do this.
