### PR TITLE
use absolute_url_path instead of getPhysicalPath

### DIFF
--- a/plomino/tinymce/browser/tinymce_plugins/plomino_tinymce/editor_plugin.js
+++ b/plomino/tinymce/browser/tinymce_plugins/plomino_tinymce/editor_plugin.js
@@ -16,9 +16,9 @@
 		init : function(ed, url) {
 			// Get the physical path of the current Zope object
 			tinymce.util.XHR.send({
-				url : './getPhysicalPath',
+				url : './absolute_url_path',
 				success : function(text) {
-					zopePhysicalPath = tinymce.util.JSON.parse('[' + text.substr(1, text.length - 2) + ']').join('/');
+					zopePhysicalPath = text;
 				}
 			});
 


### PR DESCRIPTION
When using a reverse proxy and VirtualHostMonster getPhysicalPath doesn't work.
